### PR TITLE
[#5] Support CentOS 6

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -10,13 +10,24 @@ builds:
   - "entity.system.platform == 'alpine'"
   - "entity.system.arch == 'amd64'"
 
-- platform: "centos"
+- platform: "centos6"
   arch: "amd64"
-  asset_filename: "monitoring-plugins-centos_#{version}_linux_amd64.tar.gz"
+  asset_filename: "monitoring-plugins-centos6_#{version}_linux_amd64.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
   - "entity.system.platform == 'centos'"
+  - "entity.system.platform_version.split('.')[0] == '6'"
+  - "entity.system.arch == 'amd64'"
+
+- platform: "centos7"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-centos7_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform == 'centos'"
+  - "entity.system.platform_version.split('.')[0] == '7'"
   - "entity.system.arch == 'amd64'"
 
 - platform: "debian"

--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -16,7 +16,7 @@ builds:
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
-  - "entity.system.platform == 'centos'"
+  - "entity.system.platform_family == 'rhel'"
   - "entity.system.platform_version.split('.')[0] == '6'"
   - "entity.system.arch == 'amd64'"
 
@@ -26,7 +26,7 @@ builds:
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
-  - "entity.system.platform == 'centos'"
+  - "entity.system.platform_family == 'rhel'"
   - "entity.system.platform_version.split('.')[0] == '7'"
   - "entity.system.arch == 'amd64'"
 
@@ -36,5 +36,5 @@ builds:
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
-  - "entity.system.platform == 'debian'"
+  - "entity.system.platform_family == 'debian'"
   - "entity.system.arch == 'amd64'"

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -1,6 +1,6 @@
-FROM centos:7 as builder
+FROM centos:6 as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos6"
 ARG SENSU_GO_ASSET_VERSION="2.2.0"
 ARG PLUGINS="check_http"
 

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,0 +1,12 @@
+FROM centos:7 as builder
+
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos7"
+ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG PLUGINS="check_http"
+
+ADD create-sensu-asset /usr/bin/create-sensu-asset
+
+WORKDIR /usr/lib64/nagios/plugins/
+
+RUN yum install -y epel-release which && yum install -y nagios-plugins-all
+RUN create-sensu-asset -a $SENSU_GO_ASSET_NAME -b $PLUGINS -v $SENSU_GO_ASSET_VERSION -o /

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ creating a Sensu Go Asset containing the C plugins.
 
 ## Goal
 
-The goal of this project is to provide Sensu Go Assets for CentOS Linux, Debian
+The goal of this project is to provide Sensu Go Assets for CentOS Linux (6 and 7), Debian
 Linux, and Alpine Linux containing all of the plugins from the Monitoring
 Plugins project.
 
@@ -48,8 +48,8 @@ In no particular order:
 1. Clone this repo:
 
    ~~~
-   $ git clone git@github.com:calebhailey/sensu-assets-monitoring-plugins.git
-   $ cd sensu-assets-monitoring-plugins
+   $ git clone git@github.com:sensu/monitoring-plugins.git
+   $ cd monitoring-plugins
    ~~~
 
 2. Build the Docker containers and extract the Sensu assets:

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,11 @@ export PLUGINS="check_disk,check_http,check_ntp,check_ntp_peer,check_ntp_time,ch
 export SENSU_GO_ASSET_VERSION=$(git describe --abbrev=0 --tags)
 
 mkdir assets/
-for PLATFORM in alpine debian centos;
+for PLATFORM in alpine debian centos6 centos7;
 do
   export SENSU_GO_ASSET_FILENAME="monitoring-plugins-${PLATFORM}_${SENSU_GO_ASSET_VERSION}_linux_amd64.tar.gz"
-  docker build --build-arg "PLUGINS=$PLUGINS" --build-arg "SENSU_GO_ASSET_VERSION=$SENSU_GO_ASSET_VERSION" -t monitoring-plugins-${PLATFORM}:$SENSU_GO_ASSET_VERSION -f Dockerfile.${PLATFORM} .
-  docker cp -L $(docker create monitoring-plugins-${PLATFORM}:$SENSU_GO_ASSET_VERSION true):/$SENSU_GO_ASSET_FILENAME ./assets/
+  docker build --no-cache --rm --build-arg "PLUGINS=$PLUGINS" --build-arg "SENSU_GO_ASSET_VERSION=$SENSU_GO_ASSET_VERSION" -t monitoring-plugins-${PLATFORM}:$SENSU_GO_ASSET_VERSION -f Dockerfile.${PLATFORM} .
+  docker cp -L $(docker create --rm monitoring-plugins-${PLATFORM}:$SENSU_GO_ASSET_VERSION true):/$SENSU_GO_ASSET_FILENAME ./assets/
 done;
 
 cd assets/


### PR DESCRIPTION
Resolves #5 

Adjusts build.sh to build a CentOS 6 as well as CentOS 7
monitoring-plugins asset. Also sets temporary build containers to remove
themselves after assets have been exported, as to not leave "exited" or
"/bin/true" containers lying around.

Adds a CentOS 6 Dockerfile, and renames the existing Dockerfile.centos
Dockerfile for CentOS 7 to keep filenames consistent.

Fixes a few old references in the README, and adjusts the bonsai
configuration to build separate assets for CentOS 6 vs 7.

Signed-off-by: James Tooze <toozej@gmail.com>