### PR TITLE
[Issue #2] Add more platforms

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -10,6 +10,16 @@ builds:
   - "entity.system.platform == 'alpine'"
   - "entity.system.arch == 'amd64'"
 
+- platform: "amazon1"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-amazon1_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform == 'amazon'"
+  - "entity.system.platform_version.split('.')[0] == '2018'"
+  - "entity.system.arch == 'amd64'"
+
 - platform: "amazon2"
   arch: "amd64"
   asset_filename: "monitoring-plugins-amazon2_#{version}_linux_amd64.tar.gz"
@@ -17,7 +27,7 @@ builds:
   filter:
   - "entity.system.os == 'linux'"
   - "entity.system.platform == 'amazon'"
-  - "entity.system.platform_version.split('.')[0] == '2'"
+  - "entity.system.platform_version == '2'"
   - "entity.system.arch == 'amd64'"
 
 - platform: "centos6"
@@ -40,11 +50,62 @@ builds:
   - "entity.system.platform_version.split('.')[0] == '7'"
   - "entity.system.arch == 'amd64'"
 
-- platform: "debian"
+- platform: "centos8"
   arch: "amd64"
-  asset_filename: "monitoring-plugins-debian_#{version}_linux_amd64.tar.gz"
+  asset_filename: "monitoring-plugins-centos8_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform_family == 'rhel'"
+  - "entity.system.platform_version.split('.')[0] == '8'"
+  - "entity.system.arch == 'amd64'"
+
+- platform: "debian8"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-debian8_#{version}_linux_amd64.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
   - "entity.system.platform_family == 'debian'"
+  - "entity.system.platform_version.split('.')[0] == '8'"
+  - "entity.system.arch == 'amd64'"
+
+- platform: "debian9"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-debian9_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform_family == 'debian'"
+  - "entity.system.platform_version.split('.')[0] == '9'"
+  - "entity.system.arch == 'amd64'"
+
+- platform: "debian10"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-debian10_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform_family == 'debian'"
+  - "entity.system.platform_version.split('.')[0] == '10'"
+  - "entity.system.arch == 'amd64'"
+
+- platform: "ubuntu1604"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-ubuntu1604_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform_family == 'ubuntu'"
+  - "entity.system.platform_version.split('.')[0] == '16'"
+  - "entity.system.arch == 'amd64'"
+
+- platform: "ubuntu1804"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-ubuntu1804_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform_family == 'ubuntu'"
+  - "entity.system.platform_version.split('.')[0] == '18'"
   - "entity.system.arch == 'amd64'"

--- a/Dockerfile.centos8
+++ b/Dockerfile.centos8
@@ -1,6 +1,6 @@
-FROM amazonlinux:1 as builder
+FROM centos:8 as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon1"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos8"
 ARG SENSU_GO_ASSET_VERSION="2.2.0"
 ARG PLUGINS="check_http"
 
@@ -8,5 +8,5 @@ ADD create-sensu-asset /usr/bin/create-sensu-asset
 
 WORKDIR /usr/lib64/nagios/plugins/
 
-RUN yum-config-manager --enable epel && yum install -y which tar nagios-plugins-all
+RUN yum install -y epel-release which && yum --enablerepo=PowerTools install -y nagios-plugins-all
 RUN create-sensu-asset -a $SENSU_GO_ASSET_NAME -b $PLUGINS -v $SENSU_GO_ASSET_VERSION -o /

--- a/Dockerfile.debian10
+++ b/Dockerfile.debian10
@@ -1,12 +1,12 @@
-FROM amazonlinux:1 as builder
+FROM debian:buster as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon1"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-debian10"
 ARG SENSU_GO_ASSET_VERSION="2.2.0"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
 
-WORKDIR /usr/lib64/nagios/plugins/
+WORKDIR /usr/lib/nagios/plugins/
 
-RUN yum-config-manager --enable epel && yum install -y which tar nagios-plugins-all
+RUN apt-get update && apt-get install -y monitoring-plugins-basic
 RUN create-sensu-asset -a $SENSU_GO_ASSET_NAME -b $PLUGINS -v $SENSU_GO_ASSET_VERSION -o /

--- a/Dockerfile.debian8
+++ b/Dockerfile.debian8
@@ -1,6 +1,6 @@
-FROM debian:stretch as builder
+FROM debian:jessie as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-debian"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-debian8"
 ARG SENSU_GO_ASSET_VERSION="2.2.0"
 ARG PLUGINS="check_http"
 

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -1,12 +1,12 @@
-FROM amazonlinux:1 as builder
+FROM debian:stretch as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon1"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-debian9"
 ARG SENSU_GO_ASSET_VERSION="2.2.0"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
 
-WORKDIR /usr/lib64/nagios/plugins/
+WORKDIR /usr/lib/nagios/plugins/
 
-RUN yum-config-manager --enable epel && yum install -y which tar nagios-plugins-all
+RUN apt-get update && apt-get install -y monitoring-plugins-basic
 RUN create-sensu-asset -a $SENSU_GO_ASSET_NAME -b $PLUGINS -v $SENSU_GO_ASSET_VERSION -o /

--- a/Dockerfile.ubuntu1604
+++ b/Dockerfile.ubuntu1604
@@ -1,12 +1,12 @@
-FROM amazonlinux:1 as builder
+FROM ubuntu:16.04 as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon1"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-ubuntu1604"
 ARG SENSU_GO_ASSET_VERSION="2.2.0"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
 
-WORKDIR /usr/lib64/nagios/plugins/
+WORKDIR /usr/lib/nagios/plugins/
 
-RUN yum-config-manager --enable epel && yum install -y which tar nagios-plugins-all
+RUN apt-get update && apt-get install -y monitoring-plugins-basic
 RUN create-sensu-asset -a $SENSU_GO_ASSET_NAME -b $PLUGINS -v $SENSU_GO_ASSET_VERSION -o /

--- a/Dockerfile.ubuntu1804
+++ b/Dockerfile.ubuntu1804
@@ -1,12 +1,12 @@
-FROM amazonlinux:1 as builder
+FROM ubuntu:18.04 as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon1"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-ubuntu1804"
 ARG SENSU_GO_ASSET_VERSION="2.2.0"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
 
-WORKDIR /usr/lib64/nagios/plugins/
+WORKDIR /usr/lib/nagios/plugins/
 
-RUN yum-config-manager --enable epel && yum install -y which tar nagios-plugins-all
+RUN apt-get update && apt-get install -y monitoring-plugins-basic
 RUN create-sensu-asset -a $SENSU_GO_ASSET_NAME -b $PLUGINS -v $SENSU_GO_ASSET_VERSION -o /

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ creating a Sensu Go Asset containing the C plugins.
 
 ## Goal
 
-The goal of this project is to provide Sensu Go Assets for CentOS Linux (6 and 7), Debian
-Linux, and Alpine Linux containing all of the plugins from the Monitoring
-Plugins project.
+The goal of this project is to provide Sensu Go Assets for CentOS/RHEL Linux (6, 7, and 8), Debian Linux (8, 9, and 10), Ubuntu Linux (16.04 and 18.04), and Alpine Linux containing all of the plugins from the Monitoring Plugins project.
 
 ### Current Status
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ export PLUGINS="check_disk,check_http,check_ntp,check_ntp_peer,check_ntp_time,ch
 export SENSU_GO_ASSET_VERSION=$(git describe --abbrev=0 --tags)
 
 mkdir assets/
-for PLATFORM in alpine amazon2 debian centos6 centos7;
+for PLATFORM in alpine amazon1 amazon2 debian8 debian9 debian10 centos6 centos7 centos8 ubuntu1604 ubuntu1804;
 do
   export SENSU_GO_ASSET_FILENAME="monitoring-plugins-${PLATFORM}_${SENSU_GO_ASSET_VERSION}_linux_amd64.tar.gz"
   docker build --no-cache --rm --build-arg "PLUGINS=$PLUGINS" --build-arg "SENSU_GO_ASSET_VERSION=$SENSU_GO_ASSET_VERSION" -t monitoring-plugins-${PLATFORM}:$SENSU_GO_ASSET_VERSION -f Dockerfile.${PLATFORM} .

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -18,7 +18,7 @@ export PLUGINS="check_disk,check_http,check_ntp,check_ntp_peer,check_ntp_time,ch
 [[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty, upload disabled" ; }
 [[ -z "$TRAVIS_REPO_SLUG" ]] && { echo "TRAVIS_REPO_SLUG is empty"; exit 1; }
 if [[ -z "$1" ]]; then 
-  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine debian centos alpine3.8 debian9 centos7 centos6 amazon2 ); 
+  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine alpine3.8 debian8 debian9 debian10 centos8 centos7 centos6 amazon1 amazon2 ubuntu1604 ubuntu1804 ); 
 else
   IFS=', ' read -r -a platforms <<< "$1"
 fi


### PR DESCRIPTION
Fixes https://github.com/sensu/monitoring-plugins/issues/2 and https://github.com/sensu/monitoring-plugins/issues/11

- Fixes build for Amazon Linux 1
- Fixes Bonsai filter logic for Amazon Linux 2 
- Adds build for CentOS 8 (based off existing CentOS 7 build)
- Adds build for Debian 8 and 10 (based off existing Debian 9 build)
- Adds build for Ubuntu 16.04 and 18.04 (based off existing Debian 9
build)

Signed-off-by: James Tooze <toozej@gmail.com>