### PR TITLE
fix Amazon Linux and Ubuntu asset filters

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -17,7 +17,9 @@ builds:
   filter:
   - "entity.system.os == 'linux'"
   - "entity.system.platform == 'amazon'"
-  - "entity.system.platform_version.split('.')[0] == '2018'"
+  # Amazon Linux 1 uses versions of the format YYYY.MM starting from 2011 and going until 2018
+  # thus we are matching if the YYYY portion of platform_version contains '201'
+  - "entity.system.platform_version.split('.')[0].indexOf('201') !== -1"
   - "entity.system.arch == 'amd64'"
 
 - platform: "amazon2"
@@ -96,7 +98,7 @@ builds:
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
-  - "entity.system.platform_family == 'ubuntu'"
+  - "entity.system.platform == 'ubuntu'"
   - "entity.system.platform_version.split('.')[0] == '16'"
   - "entity.system.arch == 'amd64'"
 
@@ -106,6 +108,6 @@ builds:
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
-  - "entity.system.platform_family == 'ubuntu'"
+  - "entity.system.platform == 'ubuntu'"
   - "entity.system.platform_version.split('.')[0] == '18'"
   - "entity.system.arch == 'amd64'"


### PR DESCRIPTION
Fixes incorrect asset filters in bonsai.yml

1) Amazon Linux 1 uses versions of the format YYYY.MM starting from 2011 and going until 2018, thus we are matching if the YYYY portion of platform_version contains '201'. Shout out to @nixwiz and @cwjohnston for helping me with this issue in https://sensucommunity.slack.com/archives/C68LV5M9U/p1584383938101700 

2) Ubuntu 16.04 and 18.04 should use platform instead of platform_family