### PR TITLE
Additional excludes for libraries included in assest

### DIFF
--- a/create-sensu-asset
+++ b/create-sensu-asset
@@ -3,6 +3,8 @@
 WORK_DIR=/tmp/sensu-assets
 BUILD_DIR=$WORK_DIR/build
 OUTPUT_DIR=$PWD
+GREP_EXCLUDE='(ld.so|ld-linux-x86-64.so|libBrokenLocale.so|libSegFault.so|libanl.so|libc.so|libdl.so|libm.so|libmvec.so|libnss_compat.so|libnss_dns.so|libnss_files.so|libpthread.so|libresolv.so|librt.so|libthread_db.so|libutil.so|vdso.so)'
+
 mkdir -p $BUILD_DIR
 
 # Read arguments
@@ -108,7 +110,7 @@ if [[ -n $BINS ]]; then
       echo "Copying: $BINARY into the asset bin/$BINARY"
       cp $BINARY $PKG_DIR/bin/;
       if [[ $(which ldd) ]]; then
-        LINKED_LIBRARIES=($(ldd $BINARY | grep "=>" | grep -v "vdso.so.1" | awk '{print $3}'))
+        LINKED_LIBRARIES=($(ldd $BINARY | grep "=>" | egrep -v "${GREP_EXCLUDE}" | awk '{print $3}'))
         for INDEX in "${!LINKED_LIBRARIES[@]}"
         do
           LINKED_LIBRARY="${LINKED_LIBRARIES[$INDEX]}"


### PR DESCRIPTION
Certain unnecessary/conflicting libraries were being included in the asset.  This removes them.

Closes #22 

Signed-off-by: Todd Campbell <todd@sensu.io>