### PR TITLE
Updating Versions - Fixing Cent6 Build

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine:latest as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-alpine"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -9,9 +9,9 @@ ADD create-sensu-asset /usr/bin/create-sensu-asset
 WORKDIR /
 
 RUN apk --update add bash coreutils libintl curl gcc g++ make openssl-dev net-snmp-tools linux-headers procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.amazon1
+++ b/Dockerfile.amazon1
@@ -1,7 +1,7 @@
 FROM amazonlinux:1 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon1"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -9,9 +9,9 @@ ADD create-sensu-asset /usr/bin/create-sensu-asset
 WORKDIR /
 
 RUN yum groupinstall -y "Development Tools" && yum install -y curl expat-devel openssl openssl-devel net-snmp-utils bind-utils && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.amazon2
+++ b/Dockerfile.amazon2
@@ -1,7 +1,7 @@
 FROM amazonlinux:2 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon2"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN yum groupinstall -y "Development Tools" && \
     yum install -y curl expat-devel openssl openssl-devel net-snmp-utils bind-utils which procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -1,7 +1,7 @@
 FROM centos:6 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos6"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -13,9 +13,9 @@ WORKDIR /
 RUN curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
 
 RUN yum groupinstall -y "Development Tools" && yum install -y curl expat-devel openssl openssl-devel net-snmp-utils bind-utils && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.centos6
+++ b/Dockerfile.centos6
@@ -10,6 +10,8 @@ WORKDIR /usr/lib64/nagios/plugins/
 
 WORKDIR /
 
+RUN curl https://www.getpagespeed.com/files/centos6-eol.repo --output /etc/yum.repos.d/CentOS-Base.repo
+
 RUN yum groupinstall -y "Development Tools" && yum install -y curl expat-devel openssl openssl-devel net-snmp-utils bind-utils && \
     curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
     tar xzf monitoring-plugins-2.2.tar.gz && \

--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -1,7 +1,7 @@
 FROM centos:7 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos7"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN yum groupinstall -y "Development Tools" && \
     yum install -y curl expat-devel openssl openssl-devel net-snmp-utils bind-utils which procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.centos8
+++ b/Dockerfile.centos8
@@ -1,7 +1,7 @@
 FROM centos:8 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos8"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -12,9 +12,9 @@ RUN rm -rf /var/cache/dnf && \
     dnf -y upgrade && \
     dnf groupinstall -y "Development Tools" && \
     dnf install -y curl expat-devel openssl openssl-devel net-snmp-utils bind-utils which procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.debian10
+++ b/Dockerfile.debian10
@@ -1,7 +1,7 @@
 FROM debian:buster as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-debian10"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN apt-get update && \
     apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev snmp dnsutils procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.debian8
+++ b/Dockerfile.debian8
@@ -1,7 +1,7 @@
 FROM debian:jessie as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-debian8"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN apt-get update && \
     apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev snmp dnsutils && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.debian9
+++ b/Dockerfile.debian9
@@ -1,7 +1,7 @@
 FROM debian:stretch as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-debian9"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN apt-get update && \
     apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev snmp dnsutils procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.ubuntu1404
+++ b/Dockerfile.ubuntu1404
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-ubuntu1404"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN apt-get update && \
     apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev snmp dnsutils procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.ubuntu1604
+++ b/Dockerfile.ubuntu1604
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-ubuntu1604"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN apt-get update && \
     apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev snmp dnsutils procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.ubuntu1804
+++ b/Dockerfile.ubuntu1804
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-ubuntu1804"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -10,9 +10,9 @@ WORKDIR /
 
 RUN apt-get update && \
     apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev snmp dnsutils procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install

--- a/Dockerfile.ubuntu2004
+++ b/Dockerfile.ubuntu2004
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as builder
 
 ARG SENSU_GO_ASSET_NAME="monitoring-plugins-ubuntu2004"
-ARG SENSU_GO_ASSET_VERSION="2.2.0"
+ARG SENSU_GO_ASSET_VERSION="2.3.1"
 ARG PLUGINS="check_http"
 
 ADD create-sensu-asset /usr/bin/create-sensu-asset
@@ -12,9 +12,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
     apt-get install -y build-essential curl libexpat1-dev openssl libssl-dev libz-dev snmp dnsutils procps && \
-    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.2.tar.gz && \
-    tar xzf monitoring-plugins-2.2.tar.gz && \
-    cd monitoring-plugins-2.2 && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
     ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
     make && \
     make install


### PR DESCRIPTION
CentOS builds failed due to repo issues, and I added a new Base repo to the Dockerfile. Also, specific checks such as check_ping have failed on Ubuntu-1604 with errors similar to [this](https://github.com/monitoring-plugins/monitoring-plugins/issues/1509). The issue appears to have been solved with later releases, but currently, sensu is still using version 2.2.