### PR TITLE
CentOS v9 support

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -62,6 +62,16 @@ builds:
   - "entity.system.platform_version.split('.')[0] == '8'"
   - "entity.system.arch == 'amd64'"
 
+- platform: "centos9"
+  arch: "amd64"
+  asset_filename: "monitoring-plugins-centos9_#{version}_linux_amd64.tar.gz"
+  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
+  filter:
+  - "entity.system.os == 'linux'"
+  - "entity.system.platform_family == 'rhel'"
+  - "entity.system.platform_version.split('.')[0] == '9'"
+  - "entity.system.arch == 'amd64'"
+
 - platform: "debian8"
   arch: "amd64"
   asset_filename: "monitoring-plugins-debian8_#{version}_linux_amd64.tar.gz"

--- a/Dockerfile.centos9
+++ b/Dockerfile.centos9
@@ -1,0 +1,25 @@
+FROM quay.io/centos/centos:stream9 as builder
+
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-centos9"
+ARG SENSU_GO_ASSET_VERSION="2.7.0"
+ARG PLUGINS="check_http"
+
+ADD create-sensu-asset /usr/bin/create-sensu-asset
+
+WORKDIR /
+
+RUN rm -rf /var/cache/dnf
+RUN dnf -y distro-sync
+RUN dnf -y upgrade && \
+    dnf groupinstall -y "Development Tools" && \
+    dnf install -y curl-minimal expat-devel openssl openssl-devel net-snmp-utils bind-utils which procps && \
+    curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.1.tar.gz && \
+    tar xzf monitoring-plugins-2.3.1.tar.gz && \
+    cd monitoring-plugins-2.3.1 && \
+    ./configure --prefix=/usr --libexecdir=/usr/lib/monitoring-plugins && \
+    make && \
+    make install
+
+WORKDIR /usr/lib/monitoring-plugins/
+
+RUN create-sensu-asset -a $SENSU_GO_ASSET_NAME -b $PLUGINS -v $SENSU_GO_ASSET_VERSION -o /

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ export PLUGINS="check_disk,check_dns,check_http,check_load,check_log,check_ntp,c
 export SENSU_GO_ASSET_VERSION=$(git describe --abbrev=0 --tags)
 
 mkdir assets/
-for PLATFORM in alpine amazon1 amazon2 debian8 debian9 debian10 debian11 centos6 centos7 centos8 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 ;
+for PLATFORM in alpine amazon1 amazon2 debian8 debian9 debian10 debian11 centos6 centos7 centos8 centos9 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 ;
 do
   export SENSU_GO_ASSET_FILENAME="monitoring-plugins-${PLATFORM}_${SENSU_GO_ASSET_VERSION}_linux_amd64.tar.gz"
   docker build --no-cache --rm --build-arg "PLUGINS=$PLUGINS" --build-arg "SENSU_GO_ASSET_VERSION=$SENSU_GO_ASSET_VERSION" -t monitoring-plugins-${PLATFORM}:$SENSU_GO_ASSET_VERSION -f Dockerfile.${PLATFORM} .

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -18,7 +18,7 @@ export PLUGINS="check_disk,check_dns,check_http,check_load,check_log,check_ntp,c
 [[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty, upload disabled" ; }
 [[ -z "$TRAVIS_REPO_SLUG" ]] && { echo "TRAVIS_REPO_SLUG is empty"; exit 1; }
 if [[ -z "$1" ]]; then 
-  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine alpine3.8 debian8 debian9 debian10 debian11 centos8 centos7 centos6 amazon1 amazon2 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 ); 
+  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine alpine3.8 debian8 debian9 debian10 debian11 centos9 centos8 centos7 centos6 amazon1 amazon2 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 ); 
 else
   IFS=', ' read -r -a platforms <<< "$1"
 fi


### PR DESCRIPTION
I'm unsure about Stream vs a more standard RHEL clone like Rocky or Alma, but using CentOS Stream makes all the names match slightly better. I haven't tested the .bonsai.yml change, but it looks right. Builds look like they work, I can successfully run the binaries in the tarball on an EL9 host, and `./bin/check_http --ssl -H www.google.com` looks like it works fine.