### PR TITLE
Catch errors in build steps

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -2,6 +2,7 @@
 ##
 # Adapted from sensu/sensu-go-bonsai-asset repo
 ##
+set -e
 
 # Hardwiring repo-name for now, untile the Dockerfile logic is abstracted/tested to use name as passed to docker as build arg
 REPO_NAME="monitoring-plugins"


### PR DESCRIPTION
[2.9.0](https://github.com/sensu/monitoring-plugins/releases/tag/2.9.0) is missing the Alpine build, this is difficult to find when errors get ignored and jobs get marked as successful. I've tried this out, and it seems to work just fine in Github Actions, reporting errors when encountered.