### PR TITLE
Replace broken Amazon Linux 2022 asset with Amazon Linux 2023

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -20,14 +20,14 @@ builds:
   - "entity.system.platform_version == '2'"
   - "entity.system.arch == 'amd64'"
 
-- platform: "amazon2022"
+- platform: "amazon2023"
   arch: "amd64"
-  asset_filename: "monitoring-plugins-amazon2022_#{version}_linux_amd64.tar.gz"
+  asset_filename: "monitoring-plugins-amazon2023_#{version}_linux_amd64.tar.gz"
   sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
   filter:
   - "entity.system.os == 'linux'"
   - "entity.system.platform == 'amazon'"
-  - "entity.system.platform_version == '2022'"
+  - "entity.system.platform_version == '2023'"
   - "entity.system.arch == 'amd64'"
 
 - platform: "centos7"

--- a/Dockerfile.amazon2022
+++ b/Dockerfile.amazon2022
@@ -9,7 +9,7 @@ ADD create-sensu-asset /usr/bin/create-sensu-asset
 WORKDIR /
 
 RUN yum groupinstall -y "Development Tools" && \
-    yum install -y curl expat-devel openssl openssl-devel net-snmp-utils bind-utils which procps && \
+    yum install -y expat-devel openssl openssl-devel bind-utils which procps && \
     curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.3.tar.gz && \
     tar xzf monitoring-plugins-2.3.3.tar.gz && \
     cd monitoring-plugins-2.3.3 && \

--- a/Dockerfile.amazon2023
+++ b/Dockerfile.amazon2023
@@ -1,6 +1,6 @@
-FROM amazonlinux:2022 as builder
+FROM amazonlinux:2023 as builder
 
-ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon2022"
+ARG SENSU_GO_ASSET_NAME="monitoring-plugins-amazon2023"
 ARG SENSU_GO_ASSET_VERSION="2.7.0"
 ARG PLUGINS="check_http"
 
@@ -9,7 +9,7 @@ ADD create-sensu-asset /usr/bin/create-sensu-asset
 WORKDIR /
 
 RUN yum groupinstall -y "Development Tools" && \
-    yum install -y expat-devel openssl openssl-devel bind-utils which procps && \
+    yum install -y expat-devel openssl openssl-devel net-snmp-utils bind-utils which procps && \
     curl -s -L -O https://www.monitoring-plugins.org/download/monitoring-plugins-2.3.3.tar.gz && \
     tar xzf monitoring-plugins-2.3.3.tar.gz && \
     cd monitoring-plugins-2.3.3 && \

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ export SENSU_GO_ASSET_VERSION=$(git describe --abbrev=0 --tags)
 
 mkdir assets/
 
-for PLATFORM in alpine amazon2 amazon2022 debian8 debian9 debian10 debian11 centos6 centos7 centos8 rocky9 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64;
+for PLATFORM in alpine amazon2 amazon2023 debian8 debian9 debian10 debian11 centos6 centos7 centos8 rocky9 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64;
 do
   if [[ ${PLATFORM} == "raspberrypi64"  ]]; then
     export ARCH="arm64"

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ export SENSU_GO_ASSET_VERSION=$(git describe --abbrev=0 --tags)
 
 mkdir assets/
 
-for PLATFORM in alpine amazon1 amazon2 amazon2022 debian8 debian9 debian10 debian11 centos6 centos7 centos8 rocky9 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64;
+for PLATFORM in alpine amazon2 amazon2022 debian8 debian9 debian10 debian11 centos6 centos7 centos8 rocky9 ubuntu1404 ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64;
 do
   if [[ ${PLATFORM} == "raspberrypi64"  ]]; then
     export ARCH="arm64"

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -18,7 +18,7 @@ export PLUGINS="check_disk,check_dns,check_http,check_load,check_log,check_ntp,c
 [[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty, upload disabled" ; }
 [[ -z "$TRAVIS_REPO_SLUG" ]] && { echo "TRAVIS_REPO_SLUG is empty"; exit 1; }
 if [[ -z "$1" ]]; then 
-  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine amazon2 amazonlinux2022 debian10 debian11 centos7 centos8 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64 );
+  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine amazon2 amazon2022 debian10 debian11 centos7 centos8 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64 );
 else
   IFS=', ' read -r -a platforms <<< "$1"
 fi

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -18,7 +18,7 @@ export PLUGINS="check_disk,check_dns,check_http,check_load,check_log,check_ntp,c
 [[ -z "$GITHUB_TOKEN" ]] && { echo "GITHUB_TOKEN is empty, upload disabled" ; }
 [[ -z "$TRAVIS_REPO_SLUG" ]] && { echo "TRAVIS_REPO_SLUG is empty"; exit 1; }
 if [[ -z "$1" ]]; then 
-  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine amazon2 amazon2022 debian10 debian11 centos7 centos8 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64 );
+  echo "Parameter 1, PLATFORMS is empty, using default set" ; platforms=( alpine amazon2 amazon2023 debian10 debian11 centos7 centos8 ubuntu1804 ubuntu2004 ubuntu2204 raspberrypi64 );
 else
   IFS=', ' read -r -a platforms <<< "$1"
 fi


### PR DESCRIPTION
Amazon Linux 2022 has no SNMP packages, which makes the build process break down.

Also sort out some amazon202x vs amazonlinux202x disagreements.

Pairs well with #44, which will make bad builds more apparent.